### PR TITLE
Status for each company in user-selected sheet

### DIFF
--- a/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
+++ b/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
@@ -41,12 +41,22 @@ class MainActivity : ComponentActivity() {
                     // Top title bar
                     TitleBar(title = "TrackR")
                     // Dropdown of user's sheets
+                    AuthPage()
                     DisplaySheets()
                 }
             }
         }
     }
 }
+
+@Composable
+fun AuthPage() {
+    Button(onClick = { println("Button pressed") }) {
+        Text(text = "Sign in with Google")
+    }
+
+}
+
 
 @Composable
 fun TitleBar(title: String) {
@@ -81,35 +91,44 @@ fun DisplaySheets() {
         Icons.Filled.ArrowDropDown
     }
 
-    Column(Modifier.padding(20.dp)) {
-        OutlinedTextField(value = selectedText, onValueChange = { selectedText = it },
-            modifier = Modifier
-                .clickable { expanded = !expanded }
-                .fillMaxWidth()
-                .onGloballyPositioned { coordinates ->
-                    textFieldSize = coordinates.size.toSize()
-                },
-            label = { Text("YouR Sheets") },
-            trailingIcon = {
-                Icon(arrowIcon, "contentDescription", Modifier.clickable { expanded = !expanded })
-            },
-            enabled = false,
-        )
 
-        DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.width(with(LocalDensity.current) { textFieldSize.width.toDp() })
-        ) {
-            sheets.forEach { sheet ->
-                DropdownMenuItem(onClick = {
-                    selectedText = sheet
-                    expanded = false
-                }) {
-                    Text(text = sheet)
+
+    Column(Modifier.padding(20.dp)) {
+
+        Box {
+            OutlinedTextField(value = selectedText, onValueChange = { selectedText = it },
+                modifier = Modifier
+                    .clickable { expanded = !expanded }
+                    .fillMaxWidth()
+                    .onGloballyPositioned { coordinates ->
+                        textFieldSize = coordinates.size.toSize()
+                    },
+                label = { Text("YouR Sheets") },
+                trailingIcon = {
+                    Icon(arrowIcon, "contentDescription", Modifier.clickable { expanded = !expanded })
+                },
+                enabled = false,
+            )
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
+                modifier = Modifier.width(with(LocalDensity.current) { textFieldSize.width.toDp() })
+            ) {
+                sheets.forEach { sheet ->
+                    DropdownMenuItem(onClick = {
+                        selectedText = sheet
+                        expanded = false
+                    }) {
+                        Text(text = sheet)
+                    }
                 }
             }
+
+
         }
+
+
+
         // Status of selected sheet
         println(entries)
         DisplayStatus(entries)

--- a/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
+++ b/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
@@ -1,18 +1,22 @@
 package com.example.trackr_mobile
 
 import android.os.Bundle
+import android.os.TestLooperManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
+import androidx.compose.material.MaterialTheme.typography
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -20,6 +24,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.toSize
 import com.example.trackr_mobile.ui.theme.TrackrmobileTheme
 
@@ -62,6 +67,14 @@ fun DisplaySheets() {
     )
     var selectedText by remember { mutableStateOf("") }
     var textFieldSize by remember { mutableStateOf(Size.Zero) }
+    val entries = mutableListOf<String>()
+    // Eventually use API call to populate list of entries for this selected sheet
+    entries.add("Meta")
+    entries.add("Google")
+    entries.add("Amazon")
+    entries.add("Cisco")
+    entries.add("Palantir")
+
     val arrowIcon = if (expanded) {
         Icons.Filled.KeyboardArrowDown
     } else {
@@ -71,12 +84,12 @@ fun DisplaySheets() {
     Column(Modifier.padding(20.dp)) {
         OutlinedTextField(value = selectedText, onValueChange = { selectedText = it },
             modifier = Modifier
-                .clickable {  expanded = !expanded  }
+                .clickable { expanded = !expanded }
                 .fillMaxWidth()
                 .onGloballyPositioned { coordinates ->
                     textFieldSize = coordinates.size.toSize()
                 },
-            label = { Text("Your Sheets") },
+            label = { Text("YouR Sheets") },
             trailingIcon = {
                 Icon(arrowIcon, "contentDescription", Modifier.clickable { expanded = !expanded })
             },
@@ -97,13 +110,72 @@ fun DisplaySheets() {
                 }
             }
         }
+        // Status of selected sheet
+        println(entries)
+        DisplayStatus(entries)
     }
 
 }
 
 @Composable
-fun SheetsListTitle(text: String) {
+fun DisplayStatus(entries: MutableList<String>) {
+    Column {
+        for (entry in entries) {
+            CustomRadioGroup(company = entry)
+        }
+    }
+}
 
+@Composable
+fun CustomRadioGroup(company: String) {
+    val options = listOf(
+        "Applied",
+        "Interviewing",
+        "Offer",
+        "Rejected"
+    )
+    // GET request can populate this variable with what is actually in the sheet
+    var selectedOption by remember { mutableStateOf("Applied") }
+    val onSelectedChange = { text: String ->
+        selectedOption = text
+    }
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(text = company, modifier = Modifier.padding(end = 3.dp))
+        options.forEach { text ->
+            Row(
+                modifier = Modifier.padding(all = 2.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Text(
+                    text = text,
+                    style = typography.body1.merge(),
+                    fontSize = 12.sp,
+                    color = Color.White,
+                    modifier = Modifier
+                        .clip(
+                            shape = RoundedCornerShape(
+                                size = 8.dp,
+                            ),
+                        )
+                        .clickable {
+                            // Make a POST to update the Google sheet
+                            onSelectedChange(text)
+                        }
+                        .background(
+                            if (text == selectedOption) {
+                                Color(0xFF095778)
+                            } else {
+                                Color.LightGray
+                            }
+                        )
+                        .padding(
+                            vertical = 10.dp,
+                            horizontal = 10.dp
+                        )
+                )
+            }
+        }
+    }
 }
 
 @Preview(showBackground = true)
@@ -111,5 +183,6 @@ fun SheetsListTitle(text: String) {
 fun DefaultPreview() {
     TrackrmobileTheme {
         TitleBar(title = "TrackR")
+        DisplaySheets()
     }
 }

--- a/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
+++ b/app/src/main/java/com/example/trackr_mobile/MainActivity.kt
@@ -41,7 +41,6 @@ class MainActivity : ComponentActivity() {
                     // Top title bar
                     TitleBar(title = "TrackR")
                     // Dropdown of user's sheets
-                    AuthPage()
                     DisplaySheets()
                 }
             }


### PR DESCRIPTION
Screenshot: 
![Screen Shot 2022-11-10 at 11 53 26 AM](https://user-images.githubusercontent.com/59549730/201157521-6620dbc1-01e1-4b77-8c55-2070a8251aa0.png)

As of now, we have hardcoded company names that would represent the first column of the user's Google sheet for each row. For each company, the user can adjust the status. Right now, no backend API calls are being made to get or update the google sheet but this will be the next step.